### PR TITLE
Fix discovery error handling

### DIFF
--- a/app/api/discovery/route.ts
+++ b/app/api/discovery/route.ts
@@ -20,13 +20,13 @@ export async function POST(req: NextRequest) {
         const response = await fetch(queryUrl, { headers });
 
         if (!response.ok) {
-          return null;
+          throw response.status;
         }
 
         const { data, status }: PrometheusQueryResponse = await response.json();
 
         if (status !== "success") {
-          return null;
+          throw 500;
         }
 
         return {


### PR DESCRIPTION
## Summary
- return actual HTTP errors from Prometheus discovery API

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: Exit handler never called)*